### PR TITLE
Fixed an Issue Where Script Quits Prematurely

### DIFF
--- a/VeraCracker.py
+++ b/VeraCracker.py
@@ -71,11 +71,18 @@ def windowsCrack(p):
 
 
 def linuxCrack(p):
+  
+  cmd=VeraLinuxCMD%(args.v, "thisisnotthecorrectpassword")
+  process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  out, err = process.communicate()
+  err_message = str(out, "utf-8").strip() if out else str(err, "utf-8").strip()
+  
   cmd=VeraLinuxCMD%(args.v, p)
   process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   out, err = process.communicate()
+  
   procreturn = str(out, "utf-8").strip() if out else str(err, "utf-8").strip()
-  if procreturn == "Error: Incorrect password/PRF or not a valid volume.":
+  if procreturn == err_message:
     return False
   elif procreturn == "Error: Failed to obtain administrator privileges.":
     sys.exit("This script requires root previleges")


### PR DESCRIPTION
Fixed an issue where script quits without trying all passwords or finding correct password. The reason is the following line:

`if procreturn == "Error: Incorrect password/PRF or not a valid volume.":`

And up-to-date veracrypt version doesn't use this string.

Instead I did a mock password trial to obtain error message, then compared to that message:
Following block obtains the error message:

`cmd=VeraLinuxCMD%(args.v, "thisisnotthecorrectpassword")
process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
out, err = process.communicate()
err_message = str(out, "utf-8").strip() if out else str(err, "utf-8").strip()`

then we change that line to this:

`if procreturn == err_message: `

to fix the issue.
